### PR TITLE
Make tests automatically import from /testdata.

### DIFF
--- a/src/atmos.py
+++ b/src/atmos.py
@@ -16,10 +16,10 @@ from testdata import sample
 # Application Entrypoint
 if __name__ == "__main__":
 
-    tl = TestLoader()
+    loader = TestLoader()
     
     welc = welcome.WelcomeScreen()      # Main menu (mode select)
-    test = test_menu.TestMenu(tl)         # Test menu
+    test = test_menu.TestMenu(loader)         # Test menu
     sim = sim_menu.SimMenu()            # Simulation menu
     mos = mops_menu.MissionOpsMenu()    # Mission Ops menu
 

--- a/src/menus/test_menu.py
+++ b/src/menus/test_menu.py
@@ -60,8 +60,8 @@ class TestMenu(MENU_TYPE):
             # self.next = self.lookup_menu("TestLoaderMenu")
             # self.test = sample.SampleTest()  # TODO ^^ implement this instead
             self.loader.unload()
-            self.loader.load(0)  # 0 is a placeholder for now until better loading is implemented
-            self.message += f"\nLoaded: {self.test.__class__.__name__}"  # This will keep adding
+            self.loader.load("SampleTest")  # 0 is a placeholder for now until better loading is implemented
+            self.message += f"\nLoaded: {self.test.__name__}"  # This will keep adding
                                                                          # but never removing...
 
         elif data == 2:

--- a/src/test_loader.py
+++ b/src/test_loader.py
@@ -1,4 +1,53 @@
-from testdata.test_registry import *
+from importlib import import_module
+from os import listdir, path
+
+class DynamicImporter:
+    """
+    Allows for dynamic loading of test classes into the TestLoader at runtime
+    NOTE: This is probably not "pythonic" but it works so...
+    """
+
+    # TODO: Add hot-reloading so that tests written while an ATMOS instance is running can be
+    #       included automatically
+
+    _instance = None
+    class_list = {}  # a dictionary ("ClassName": Class,)
+
+    def __init__(self):
+        """
+        Initializes the DynamicImporter instance.
+        Traverses the files in the /testdata directory and imports classes with the naming
+        convention: filename.py -> class FilenameTest
+        """
+        if DynamicImporter._instance is not None:
+            raise Exception("DynamicImporter instance already exists!")
+        DynamicImporter._instance = self
+
+        test_path = path.join(path.dirname(path.abspath(__file__)), "testdata")
+        files = listdir(test_path)
+
+        for f in files:
+            if f in ["test_module.py", "test_registry.py"]:
+                continue
+            # print(f)
+            name = "".join(f.split(".")[:-1])
+            print(f"Name: {name}")
+            if name not in ["", "\n", "\r", "\r\n"]:
+                module = import_module(f"testdata.{name}")  # import the module dynamically
+                class_title = f"{name.title()}Test"
+                _class = getattr(module, class_title)  # get the class
+                print(f"Class: {_class}")
+                self.class_list[class_title] = _class  # add the class to the class list
+    
+    @staticmethod
+    def instance():
+        """
+        Static access method
+        """
+        if DynamicImporter._instance is None:
+            DynamicImporter()
+        return DynamicImporter._instance
+
 
 class TestLoader:
     """
@@ -7,15 +56,14 @@ class TestLoader:
 
     def __init__(self):
         self.menu = None
-        self.library = [
-            SampleTest,
-        ]
+        self.importer = DynamicImporter.instance()
+        self.library = self.importer.class_list
     
     def set_menu(self, menu):
         self.menu = menu
 
-    def load(self, test):
-        self.menu.load_test(SampleTest())  # TODO make this actually load different tests...
+    def load(self, test_name: str):
+        self.menu.load_test(self.library[test_name])  # TODO make this actually load different tests...
     
     def unload(self):
         self.menu.load_test(None)

--- a/src/testdata/README.md
+++ b/src/testdata/README.md
@@ -1,0 +1,74 @@
+# Test Creation Guide
+
+So, you want to make a new ATMOS test routine?
+
+We (the ATMOS team) have tried to keep it nice and simple so that you can test and test
+to your heart's delight and never grow tired of it. Here's how it's done:
+
+## 1. Create the file
+In the `/src/testdata` directory or a subfolder (organize however),
+create a new Python file (`.py` file extension). This file should be named
+clearly so it is obvious what kind of test it is. Since the name of this
+file will determine the name of the test class in Step 3, it must follow
+Python's naming rules. Basically:
+
+* Must begin with a letter or underscore
+* No special characters except underscore
+* Don't use reserved Python keywords
+
+## 2. Import stuff
+One of the first lines of the file should be (excluding any other `import` statements you may need/want):
+```python
+from .test_module import Test
+```
+This lets you make use of the `Test` base class which comes with a bunch
+of (hopefully) helpful utility functions so that you can focus on how your
+test will execute and worry less about writing lots of lines of Python
+(leave that part to us).
+
+## 3. Make a test class
+ATMOS tests are structured as classes that inherit from the `Test` abstract
+base class. **Please don't make any changes to** `Test` **directly, and**
+**please don't override any methods other than** `execute()`, **thanks!**
+
+"What shall I name my super-cool ATMOS test class?" you wonder aloud. The
+class name ***must*** have the same name as the Python file it lives in,
+but with the first letter of each **word** (i.e. anything separated by underscores) capitalized, followed by the word `Test`. For
+example:
+```python
+# File: example.py
+from .test_module import Test
+class ExampleTest(Test):
+    # ...
+```
+```python
+# File: my_super_cool_test.py
+from .test_module import Test
+class My_Super_Cool_TestTest(Test):
+    # this super cool name turned out to be super weird looking
+    # ...
+```
+## 4. Override the `execute()` method
+This method is where you put the body of your test code. Note that keyword
+arguments are permitted, but positional arguments are not. This overridden
+method basically just needs to follow one rule: return `True` if it is able
+to execute to the end with no exceptions, `False` if there is an error,
+even if it is handled in a `try...except` block (which it should be so
+that ATMOS doesn't crash).
+
+A complete (but useless) example follows:
+```python
+# File: something.py
+from .test_module import Test
+
+class SomethingTest(Test):
+    """ This is my amazing test of... something """
+
+    def execute(self, length=1, width=2, height=3):
+        """ A better docstring is needed """
+
+        volume = length * width * height
+        print(f"Volume: {volume}")
+
+        return True
+```

--- a/src/testdata/test_registry.py
+++ b/src/testdata/test_registry.py
@@ -1,5 +1,0 @@
-# test_registry.py
-# Collects all of the imports for each custom-written test
-
-# Insert all imports here
-from .sample import SampleTest


### PR DESCRIPTION
**Summary**

* Allows tests to be dynamically imported from the `/testdata` directory, so end users just have to drop files there and that's it.
* Adds a README to the `/testdata` folder so that end users can see the basic steps for creating test classes.

**Other Notes**

Eventually I think it would be good if we can have the test files elsewhere but copy them at runtime into a folder where they can be imported from. Easier for the users, I think.