### PR TITLE
Jdrempel/test loader menu

### DIFF
--- a/src/atmos.py
+++ b/src/atmos.py
@@ -8,6 +8,7 @@ from menus import (
     mops_menu,
     sim_menu,
     test_menu,
+    test_loader_menu,
     welcome,
 )
 from test_loader import TestLoader
@@ -19,7 +20,10 @@ if __name__ == "__main__":
     loader = TestLoader()
     
     welc = welcome.WelcomeScreen()      # Main menu (mode select)
+
     test = test_menu.TestMenu(loader)         # Test menu
+    load = test_loader_menu.TestLoaderMenu(loader)
+
     sim = sim_menu.SimMenu()            # Simulation menu
     mos = mops_menu.MissionOpsMenu()    # Mission Ops menu
 

--- a/src/menus/test_loader_menu.py
+++ b/src/menus/test_loader_menu.py
@@ -2,17 +2,14 @@
 # Contains the TestLoaderMenu class which prompts the user to select a test to load into ATMOS
 
 from os import listdir, path
+from typing import Any
 
 from .config import MENU_TYPE, nav_select
 from .ui import Prompt
 
 ### Instance variables for TestLoaderMenu ###
 
-# Test loader menu prompt
-test_loader_select = {
-    # TODO: Create a method to populate this
-    #       Maybe make it an instance variable of TestLoaderMenu
-}
+
 
 class TestLoaderMenu(MENU_TYPE):
     """
@@ -29,21 +26,21 @@ class TestLoaderMenu(MENU_TYPE):
         super().__init__(*args, **kwargs)
         self.message = "======== LOAD ========"
         self.loader = loader
+        self.prompt_options = {}
 
         test_path = path.join(path.dirname(path.abspath(__file__)), "..", "testdata")
         files = listdir(test_path)
 
-        prompt_options = {}
 
         for f in files:
             if f in ["test_module.py", "test_registry.py", "connections.py"]:  # blacklist of py files
                 continue
             name = "".join(f.split(".")[:-1])
             if name not in ["", "\n", "\r", "\r\n"] and f.endswith(".py"):
-                prompt_options[len(prompt_options.keys())+1] = f"{name.title()}Test"
+                self.prompt_options[len(self.prompt_options.keys())+1] = f"{name.title()}Test"
         self.prompt = Prompt(
             "Select one of the following tests:",
-            str, prompt_options
+            Any, self.prompt_options
         )
         self.selection = None
 
@@ -52,8 +49,11 @@ class TestLoaderMenu(MENU_TYPE):
         Test Loader menu options are a list of strings corresponding to test names
         """
         self.loader.unload()
-        self.loader.load(str(data))
-        # TODO Remove me, I'm just here for the debugging
-        print(f"Loaded {data}!")  # TODO: ALlow users to enter a digit corresponding to the test they want
+        if isinstance(data, str):
+            self.loader.load(str(data))
+        elif isinstance(data, int):
+            self.loader.load(self.prompt_options[data])
+        else:
+            pass  # But we should probably handle this better
         
         self.next = self.lookup_menu("TestMenu")

--- a/src/menus/test_loader_menu.py
+++ b/src/menus/test_loader_menu.py
@@ -37,7 +37,7 @@ class TestLoaderMenu(MENU_TYPE):
                 continue
             name = "".join(f.split(".")[:-1])
             if name not in ["", "\n", "\r", "\r\n"] and f.endswith(".py"):
-                self.prompt_options[len(self.prompt_options.keys())+1] = f"{name.title()}Test"
+                self.prompt_options.update({len(self.prompt_options.keys())+1: f"{name.title()}Test"})
         self.prompt = Prompt(
             "Select one of the following tests:",
             Any, self.prompt_options

--- a/src/menus/test_loader_menu.py
+++ b/src/menus/test_loader_menu.py
@@ -1,0 +1,59 @@
+# test_loader_menu.py
+# Contains the TestLoaderMenu class which prompts the user to select a test to load into ATMOS
+
+from os import listdir, path
+
+from .config import MENU_TYPE, nav_select
+from .ui import Prompt
+
+### Instance variables for TestLoaderMenu ###
+
+# Test loader menu prompt
+test_loader_select = {
+    # TODO: Create a method to populate this
+    #       Maybe make it an instance variable of TestLoaderMenu
+}
+
+class TestLoaderMenu(MENU_TYPE):
+    """
+    The test loader menu (prompts user to select a test)
+    """
+
+    def __init__(self, loader, *args, **kwargs):
+        """
+        :precond: test_loader_select must exist in a local or non-local scope
+        :type test_loader_select: dict
+        :param loader: The TestLoader instance that will be used to load the selected test
+        :type loader: TestLoader
+        """
+        super().__init__(*args, **kwargs)
+        self.message = "======== LOAD ========"
+        self.loader = loader
+
+        test_path = path.join(path.dirname(path.abspath(__file__)), "..", "testdata")
+        files = listdir(test_path)
+
+        prompt_options = {}
+
+        for f in files:
+            if f in ["test_module.py", "test_registry.py", "connections.py"]:  # blacklist of py files
+                continue
+            name = "".join(f.split(".")[:-1])
+            if name not in ["", "\n", "\r", "\r\n"] and f.endswith(".py"):
+                prompt_options[len(prompt_options.keys())+1] = f"{name.title()}Test"
+        self.prompt = Prompt(
+            "Select one of the following tests:",
+            str, prompt_options
+        )
+        self.selection = None
+
+    def perform(self, data):
+        """
+        Test Loader menu options are a list of strings corresponding to test names
+        """
+        self.loader.unload()
+        self.loader.load(str(data))
+        # TODO Remove me, I'm just here for the debugging
+        print(f"Loaded {data}!")  # TODO: ALlow users to enter a digit corresponding to the test they want
+        
+        self.next = self.lookup_menu("TestMenu")

--- a/src/menus/test_menu.py
+++ b/src/menus/test_menu.py
@@ -57,7 +57,7 @@ class TestMenu(MENU_TYPE):
 
         if data == 1:
             # Load test
-            # self.next = self.lookup_menu("TestLoaderMenu")
+            self.next = self.lookup_menu("TestLoaderMenu")
             # self.test = sample.SampleTest()  # TODO ^^ implement this instead
             self.loader.unload()
             self.loader.load("SampleTest")  # 0 is a placeholder for now until better loading is implemented

--- a/src/menus/test_menu.py
+++ b/src/menus/test_menu.py
@@ -58,10 +58,6 @@ class TestMenu(MENU_TYPE):
         if data == 1:
             # Load test
             self.next = self.lookup_menu("TestLoaderMenu")
-            self.loader.unload()
-            self.loader.load("SampleTest")  # 0 is a placeholder for now until better loading is implemented
-            self.message += f"\nLoaded: {self.test.__class__.__name__}"  # This will keep adding
-                                                                         # but never removing...
 
         elif data == 2:
             # Check connection

--- a/src/menus/test_menu.py
+++ b/src/menus/test_menu.py
@@ -58,7 +58,6 @@ class TestMenu(MENU_TYPE):
         if data == 1:
             # Load test
             self.next = self.lookup_menu("TestLoaderMenu")
-            # self.test = sample.SampleTest()  # TODO ^^ implement this instead
             self.loader.unload()
             self.loader.load("SampleTest")  # 0 is a placeholder for now until better loading is implemented
             self.message += f"\nLoaded: {self.test.__class__.__name__}"  # This will keep adding

--- a/src/menus/ui.py
+++ b/src/menus/ui.py
@@ -175,10 +175,12 @@ class TUI(UI):
         """
         return self.inputSrc.get()
     
-    def get_num(self) -> Union[int, float]:
+    def get_num(self, any=False) -> Union[int, float]:
         """
         Gets a user-entered number from the terminal
 
+        :param any: (optional) If True, allow this method to return a valid str if the input cannot be converted
+        :type any: bool
         :return: The number (int or float) that the user entered
         :rtype: Union[int, float]
         """
@@ -193,6 +195,8 @@ class TUI(UI):
             else:
                 return None
         except ValueError:
+            if any == True:
+                return input_str
             return None
     
     def output(self, string: str) -> None:
@@ -215,7 +219,13 @@ class TUI(UI):
         """
         self.output(prompt.message)
         response = None
-        if prompt.type == str:
+        if prompt.type == Any:
+            response = self.get_num(any=True)  # This could be better-implemented
+            try:
+                response = int(response)
+            except ValueError:
+                pass
+        elif prompt.type == str:
             response = self.get_str()
         elif prompt.type in [int, float]:
             response = self.get_num()

--- a/src/test_loader.py
+++ b/src/test_loader.py
@@ -64,7 +64,7 @@ class TestLoader:
         self.menu = menu
 
     def load(self, test_name: str):
-        self.menu.load_test(self.library[test_name])  # TODO make this actually load different tests...
+        self.menu.load_test(self.library[test_name])
     
     def unload(self):
         self.menu.load_test(None)

--- a/src/testdata/test_module.py
+++ b/src/testdata/test_module.py
@@ -24,8 +24,9 @@ class Test(ABC):
     """
 
     def __init__(self):
-        self.connection = SerialLine(f"Serial-{self.__class__.__name__}", "/dev/ttyUSB0", 9600)
-        self.connection.open()  # TODO: Lock the line for at least a second before allowing any tx
+        pass
+        # self.connection = SerialLine(f"Serial-{self.__class__.__name__}", "/dev/ttyUSB0", 9600)
+        # self.connection.open()  # TODO: Lock the line for at least a second before allowing any tx
 
     def _run_full(self, **kwargs) -> None:
         """


### PR DESCRIPTION
**Summary**
- Adds a new TestLoaderMenu class for selecting a test to run
- Removes old test loading code
- Allows Prompts to handle "any" type of input, i.e. it can accept either a `str` or a `int` if the correct parameter is given
- Disables the serial connection in `Test.__init__()` for now

closes #9 

**Other Notes**
- It would be good to have the serial connection in `Test.__init__()` be enabled (obviously) - perhaps the way to do this is with a try..except that catches exceptions related to the serial line not existing.